### PR TITLE
Add Scissor support to Images and Rectangles.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,9 +1040,9 @@ checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ glam = { version = "0.27.0", features = ["bytemuck", "mint"] }
 lyon = "1.0.1"
 slab = "0.4.9"
 smol_str = "0.2.1"
-indexmap = "2.2.5"
+indexmap = "2.2.6"
 genr = "0.1.0"
 
 [workspace.dependencies.camera]

--- a/graphics/src/font/render.rs
+++ b/graphics/src/font/render.rs
@@ -4,6 +4,7 @@ use crate::{
     TextVertex, Vec2,
 };
 use cosmic_text::{CacheKey, SwashCache};
+use log::{error, warn};
 
 pub struct TextAtlas {
     pub(crate) text: AtlasSet<CacheKey, Vec2>,
@@ -66,6 +67,10 @@ impl TextRenderer {
         self.add_buffer_store(renderer, index, layer);
         Ok(())
     }
+
+    pub fn use_clipping(&mut self) {
+        warn!("Text uses its own Clipping.");
+    }
 }
 
 pub trait RenderText<'a, 'b>
@@ -92,6 +97,11 @@ where
         atlas: &'b TextAtlas,
         layer: usize,
     ) {
+        if buffer.buffer.is_clipped() {
+            error!("Text uses its own clipping mechanisim it does not need to be clipped by the clipper.");
+            return;
+        }
+
         if let Some(Some(details)) = buffer.buffer.buffers.get(layer) {
             if buffer.buffer.count() > 0 {
                 self.set_buffers(renderer.buffer_object.as_buffer_pass());

--- a/graphics/src/images.rs
+++ b/graphics/src/images.rs
@@ -7,8 +7,8 @@ pub use render::*;
 pub use vertex::*;
 
 use crate::{
-    AtlasSet, Color, DrawOrder, DrawType, GpuRenderer, Index, OrderedIndex,
-    Vec2, Vec3, Vec4,
+    AtlasSet, Bounds, Color, DrawOrder, DrawType, GpuRenderer, Index,
+    OrderedIndex, Vec2, Vec3, Vec4,
 };
 
 pub enum TextDrawOrder {
@@ -36,6 +36,7 @@ pub struct Image {
     pub store_id: Index,
     pub order: DrawOrder,
     pub render_layer: u32,
+    pub bounds: Option<Bounds>,
     /// if anything got updated we need to update the buffers too.
     pub changed: bool,
 }
@@ -59,9 +60,15 @@ impl Image {
             store_id: renderer.new_buffer(),
             order: DrawOrder::default(),
             render_layer,
+            bounds: None,
             changed: true,
         }
     }
+
+    pub fn update_bounds(&mut self, bounds: Option<Bounds>) {
+        self.bounds = bounds;
+    }
+
     pub fn create_quad(
         &mut self,
         renderer: &mut GpuRenderer,
@@ -125,6 +132,6 @@ impl Image {
             self.create_quad(renderer, atlas);
         }
 
-        OrderedIndex::new(self.order, self.store_id, 0)
+        OrderedIndex::new_with_bounds(self.order, self.store_id, 0, self.bounds)
     }
 }

--- a/graphics/src/images/render.rs
+++ b/graphics/src/images/render.rs
@@ -1,6 +1,6 @@
 use crate::{
     AtlasSet, GpuRenderer, GraphicsError, Image, ImageRenderPipeline,
-    ImageVertex, InstanceBuffer, OrderedIndex, StaticBufferObject,
+    ImageVertex, InstanceBuffer, OrderedIndex, StaticBufferObject, System,
 };
 
 pub struct ImageRenderer {
@@ -38,33 +38,82 @@ impl ImageRenderer {
 
         self.add_buffer_store(renderer, index, layer);
     }
+
+    pub fn use_clipping(&mut self) {
+        self.buffer.set_as_clipped();
+    }
 }
 
-pub trait RenderImage<'a, 'b>
+pub trait RenderImage<'a, 'b, Controls>
 where
     'b: 'a,
+    Controls: camera::controls::Controls,
 {
     fn render_image(
         &mut self,
         renderer: &'b GpuRenderer,
         buffer: &'b ImageRenderer,
         atlas: &'b AtlasSet,
+        system: &'b System<Controls>,
         layer: usize,
     );
 }
 
-impl<'a, 'b> RenderImage<'a, 'b> for wgpu::RenderPass<'a>
+impl<'a, 'b, Controls> RenderImage<'a, 'b, Controls> for wgpu::RenderPass<'a>
 where
     'b: 'a,
+    Controls: camera::controls::Controls,
 {
     fn render_image(
         &mut self,
         renderer: &'b GpuRenderer,
         buffer: &'b ImageRenderer,
         atlas: &'b AtlasSet,
+        system: &'b System<Controls>,
         layer: usize,
     ) {
-        if let Some(Some(details)) = buffer.buffer.buffers.get(layer) {
+        if buffer.buffer.is_clipped() {
+            if let Some(details) = buffer.buffer.clipped_buffers.get(layer) {
+                let mut scissor_is_default = true;
+
+                if buffer.buffer.count() > 0 {
+                    self.set_bind_group(1, atlas.bind_group(), &[]);
+                    self.set_vertex_buffer(1, buffer.buffer.instances(None));
+                    self.set_pipeline(
+                        renderer.get_pipelines(ImageRenderPipeline).unwrap(),
+                    );
+                    for (details, bounds) in details {
+                        if let Some(bounds) = bounds {
+                            let bounds = system.world_to_screen(false, bounds);
+
+                            self.set_scissor_rect(
+                                bounds.x as u32,
+                                bounds.y as u32,
+                                bounds.z as u32,
+                                bounds.w as u32,
+                            );
+                            scissor_is_default = false;
+                        }
+
+                        self.draw_indexed(
+                            0..StaticBufferObject::index_count(),
+                            0,
+                            details.start..details.end,
+                        );
+
+                        if !scissor_is_default {
+                            self.set_scissor_rect(
+                                0,
+                                0,
+                                system.screen_size[0] as u32,
+                                system.screen_size[1] as u32,
+                            );
+                            scissor_is_default = true;
+                        };
+                    }
+                }
+            }
+        } else if let Some(Some(details)) = buffer.buffer.buffers.get(layer) {
             if buffer.buffer.count() > 0 {
                 self.set_bind_group(1, atlas.bind_group(), &[]);
                 self.set_vertex_buffer(1, buffer.buffer.instances(None));

--- a/graphics/src/lights/render.rs
+++ b/graphics/src/lights/render.rs
@@ -7,6 +7,7 @@ use crate::{
     MAX_DIR_LIGHTS,
 };
 
+use log::warn;
 use wgpu::util::{align_to, DeviceExt};
 
 pub struct LightRenderer {
@@ -119,6 +120,10 @@ impl LightRenderer {
         );
 
         self.add_buffer_store(renderer, index, layer);
+    }
+
+    pub fn use_clipping(&mut self) {
+        warn!("Light does not use Clipping.");
     }
 }
 

--- a/graphics/src/maps/render.rs
+++ b/graphics/src/maps/render.rs
@@ -1,3 +1,5 @@
+use log::warn;
+
 use crate::{
     AsBufferPass, AtlasSet, GpuRenderer, GraphicsError, InstanceBuffer, Map,
     MapRenderPipeline, MapVertex, OrderedIndex, SetBuffers, StaticBufferObject,
@@ -46,6 +48,10 @@ impl MapRenderer {
                 self.add_buffer_store(renderer, order_index, layers[id]);
             }
         }
+    }
+
+    pub fn use_clipping(&mut self) {
+        warn!("Light does not use Clipping.");
     }
 }
 

--- a/graphics/src/mesh2d/render.rs
+++ b/graphics/src/mesh2d/render.rs
@@ -1,6 +1,6 @@
 use crate::{
     AsBufferPass, GpuBuffer, GpuRenderer, GraphicsError, Mesh2D,
-    Mesh2DRenderPipeline, Mesh2DVertex, OrderedIndex, SetBuffers,
+    Mesh2DRenderPipeline, Mesh2DVertex, OrderedIndex, SetBuffers, System,
 };
 
 pub struct Mesh2DRenderer {
@@ -38,28 +38,36 @@ impl Mesh2DRenderer {
 
         self.add_buffer_store(renderer, index, layer);
     }
+
+    pub fn use_clipping(&mut self) {
+        self.vbos.set_as_clipped();
+    }
 }
 
-pub trait RenderMesh2D<'a, 'b>
+pub trait RenderMesh2D<'a, 'b, Controls>
 where
     'b: 'a,
+    Controls: camera::controls::Controls,
 {
     fn render_2dmeshs(
         &mut self,
         renderer: &'b GpuRenderer,
         buffer: &'b Mesh2DRenderer,
+        system: &'b System<Controls>,
         layer: usize,
     );
 }
 
-impl<'a, 'b> RenderMesh2D<'a, 'b> for wgpu::RenderPass<'a>
+impl<'a, 'b, Controls> RenderMesh2D<'a, 'b, Controls> for wgpu::RenderPass<'a>
 where
     'b: 'a,
+    Controls: camera::controls::Controls,
 {
     fn render_2dmeshs(
         &mut self,
         renderer: &'b GpuRenderer,
         buffer: &'b Mesh2DRenderer,
+        system: &'b System<Controls>,
         layer: usize,
     ) {
         if let Some(vbos) = buffer.vbos.buffers.get(layer) {
@@ -69,14 +77,49 @@ where
                     renderer.get_pipelines(Mesh2DRenderPipeline).unwrap(),
                 );
 
-                for details in vbos {
-                    // Indexs can always start at 0 per mesh data.
-                    // Base vertex is the Addition to the Index
-                    self.draw_indexed(
-                        details.indices_start..details.indices_end,
-                        details.vertex_base, //i as i32 * details.max,
-                        0..1,
-                    );
+                if buffer.vbos.is_clipped() {
+                    let mut scissor_is_default = true;
+
+                    for (details, bounds) in vbos {
+                        if let Some(bounds) = bounds {
+                            let bounds = system.world_to_screen(false, bounds);
+
+                            self.set_scissor_rect(
+                                bounds.x as u32,
+                                bounds.y as u32,
+                                bounds.z as u32,
+                                bounds.w as u32,
+                            );
+                            scissor_is_default = false;
+                        }
+                        // Indexs can always start at 0 per mesh data.
+                        // Base vertex is the Addition to the Index
+                        self.draw_indexed(
+                            details.indices_start..details.indices_end,
+                            details.vertex_base, //i as i32 * details.max,
+                            0..1,
+                        );
+
+                        if !scissor_is_default {
+                            self.set_scissor_rect(
+                                0,
+                                0,
+                                system.screen_size[0] as u32,
+                                system.screen_size[1] as u32,
+                            );
+                            scissor_is_default = true;
+                        };
+                    }
+                } else {
+                    for (details, _bounds) in vbos {
+                        // Indexs can always start at 0 per mesh data.
+                        // Base vertex is the Addition to the Index
+                        self.draw_indexed(
+                            details.indices_start..details.indices_end,
+                            details.vertex_base, //i as i32 * details.max,
+                            0..1,
+                        );
+                    }
                 }
 
                 //we need to reset this back for anything else that might need it after mesh is drawn.

--- a/graphics/src/systems/draw_order.rs
+++ b/graphics/src/systems/draw_order.rs
@@ -1,4 +1,4 @@
-use crate::{Vec2, Vec3};
+use crate::{Bounds, Vec2, Vec3};
 use genr::generational::GIdx;
 use std::cmp::Ordering;
 
@@ -61,6 +61,7 @@ pub struct OrderedIndex {
     pub(crate) index: Index,
     pub(crate) index_count: u32,
     pub(crate) index_max: u32,
+    pub(crate) bounds: Option<Bounds>,
 }
 
 impl PartialOrd for OrderedIndex {
@@ -90,6 +91,22 @@ impl OrderedIndex {
             index,
             index_count: 0,
             index_max,
+            bounds: None,
+        }
+    }
+
+    pub fn new_with_bounds(
+        order: DrawOrder,
+        index: Index,
+        index_max: u32,
+        bounds: Option<Bounds>,
+    ) -> Self {
+        Self {
+            order,
+            index,
+            index_count: 0,
+            index_max,
+            bounds,
         }
     }
 }

--- a/graphics/src/ui/rectangle.rs
+++ b/graphics/src/ui/rectangle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AtlasSet, DrawOrder, DrawType, GpuRenderer, GraphicsError, Index,
+    AtlasSet, Bounds, DrawOrder, DrawType, GpuRenderer, GraphicsError, Index,
     OrderedIndex, OtherError, RectVertex, Texture, Vec2, Vec3, Vec4,
 };
 use cosmic_text::Color;
@@ -17,6 +17,7 @@ pub struct Rect {
     pub store_id: Index,
     pub order: DrawOrder,
     pub render_layer: u32,
+    pub bounds: Option<Bounds>,
     /// if anything got updated we need to update the buffers too.
     pub changed: bool,
 }
@@ -36,8 +37,13 @@ impl Rect {
             store_id: renderer.new_buffer(),
             order: DrawOrder::default(),
             render_layer,
+            bounds: None,
             changed: true,
         }
+    }
+
+    pub fn update_bounds(&mut self, bounds: Option<Bounds>) {
+        self.bounds = bounds;
     }
 
     pub fn set_use_camera(&mut self, use_camera: bool) -> &mut Self {
@@ -169,7 +175,7 @@ impl Rect {
             self.changed = false;
         }
 
-        OrderedIndex::new(self.order, self.store_id, 0)
+        OrderedIndex::new_with_bounds(self.order, self.store_id, 0, self.bounds)
     }
 
     pub fn check_mouse_bounds(&self, mouse_pos: Vec2) -> bool {

--- a/graphics/src/ui/render.rs
+++ b/graphics/src/ui/render.rs
@@ -1,6 +1,6 @@
 use crate::{
     AtlasSet, GpuRenderer, GraphicsError, InstanceBuffer, OrderedIndex, Rect,
-    RectRenderPipeline, RectVertex, StaticBufferObject,
+    RectRenderPipeline, RectVertex, StaticBufferObject, System,
 };
 
 pub struct RectRenderer {
@@ -38,33 +38,87 @@ impl RectRenderer {
 
         self.add_buffer_store(renderer, index, layer);
     }
+
+    pub fn use_clipping(&mut self) {
+        self.buffer.set_as_clipped();
+    }
 }
 
-pub trait RenderRects<'a, 'b>
+pub trait RenderRects<'a, 'b, Controls>
 where
     'b: 'a,
+    Controls: camera::controls::Controls,
 {
     fn render_rects(
         &mut self,
         renderer: &'b GpuRenderer,
         buffer: &'b RectRenderer,
         atlas: &'b AtlasSet,
+        system: &'b System<Controls>,
         layer: usize,
     );
 }
 
-impl<'a, 'b> RenderRects<'a, 'b> for wgpu::RenderPass<'a>
+impl<'a, 'b, Controls> RenderRects<'a, 'b, Controls> for wgpu::RenderPass<'a>
 where
     'b: 'a,
+    Controls: camera::controls::Controls,
 {
     fn render_rects(
         &mut self,
         renderer: &'b GpuRenderer,
         buffer: &'b RectRenderer,
         atlas: &'b AtlasSet,
+        system: &'b System<Controls>,
         layer: usize,
     ) {
-        if let Some(Some(details)) = buffer.buffer.buffers.get(layer) {
+        if buffer.buffer.is_clipped() {
+            if let Some(details) = buffer.buffer.clipped_buffers.get(layer) {
+                let mut scissor_is_default = true;
+
+                if buffer.buffer.count() > 0 {
+                    self.set_bind_group(
+                        1,
+                        &atlas.texture_group.bind_group,
+                        &[],
+                    );
+                    self.set_vertex_buffer(1, buffer.buffer.instances(None));
+                    self.set_pipeline(
+                        renderer.get_pipelines(RectRenderPipeline).unwrap(),
+                    );
+
+                    for (details, bounds) in details {
+                        if let Some(bounds) = bounds {
+                            let bounds = system.world_to_screen(false, bounds);
+
+                            self.set_scissor_rect(
+                                bounds.x as u32,
+                                bounds.y as u32,
+                                bounds.z as u32,
+                                bounds.w as u32,
+                            );
+                            scissor_is_default = false;
+                        }
+
+                        self.draw_indexed(
+                            0..StaticBufferObject::index_count(),
+                            0,
+                            details.start..details.end,
+                        );
+
+                        if !scissor_is_default {
+                            self.set_scissor_rect(
+                                0,
+                                0,
+                                system.screen_size[0] as u32,
+                                system.screen_size[1] as u32,
+                            );
+                            scissor_is_default = true;
+                        };
+                    }
+                }
+            }
+        } else if let Some(Some(details)) = buffer.buffer.buffers.get(layer) {
             if buffer.buffer.count() > 0 {
                 self.set_bind_group(1, &atlas.texture_group.bind_group, &[]);
                 self.set_vertex_buffer(1, buffer.buffer.instances(None));


### PR DESCRIPTION
this redoes how instance buffers and VBO buffers work adding in a compatibility layer to allow scissor clipping objects using the renderers set_scissor_rect function when enabled.